### PR TITLE
First release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 graft vendor/llama.cpp
 prune vendor/llama.cpp/.git
+prune vendor/llama.cpp/models
+prune vendor/llama.cpp/examples
 # recursive-include vendor/llama.cpp *

--- a/README.md
+++ b/README.md
@@ -37,3 +37,40 @@ To update the `vendor/llama.cpp` submodule to a new release tag, follow these st
     ```
 
 This will ensure that the main project now points to the updated version of the `llama.cpp` submodule.
+
+## Building the Wheel
+
+To build the Python wheel for this package, follow these steps:
+
+1.  **Ensure `vendor` is a Package**:
+    Make sure you have an empty `__init__.py` file in the `vendor` directory (`vendor/__init__.py`). This is necessary for the build system to recognize the `vendor` directory as a Python package and include its contents. If it doesn't exist, create it:
+    ```bash
+    touch vendor/__init__.py
+    ```
+
+2.  **Configure `setup.py` and `MANIFEST.in`**:
+    *   In your `setup.py` file, ensure that `include_package_data=True` is set within the `setup()` function.
+    *   Your `MANIFEST.in` file should include a line to recursively add all files from the `vendor/llama.cpp` directory. For example:
+        ```
+        graft vendor/llama.cpp
+        ```
+        You might also want to include other necessary files or prune unwanted ones using other `MANIFEST.in` commands.
+
+3.  **Clean Previous Builds (Optional but Recommended)**:
+    Before building, it's a good practice to clean any artifacts from previous builds:
+    ```bash
+    rm -rf dist build *.egg-info
+    ```
+
+4.  **Build the Wheel**:
+    Run the following command from the root directory of the project (where `setup.py` is located):
+    ```bash
+    python3 setup.py bdist_wheel
+    ```
+
+This command will generate a `.whl` file in the `dist/` directory. This wheel file will contain the `vendor/llama.cpp` directory and its contents, which are essential for the C++ backend.
+
+You can then install the wheel using pip:
+```bash
+pip install dist/llama_cpp_pydist-*.whl
+```

--- a/build_notes.md
+++ b/build_notes.md
@@ -1,0 +1,103 @@
+\
+# Build Notes for `llama_cpp_pydist`
+
+This document outlines the process and rationale for building the `llama_cpp_pydist` Python package, particularly concerning the inclusion and management of the `vendor/llama.cpp` C++ submodule.
+
+## Goal
+
+The primary goal is to create a Python wheel (`.whl`) that:
+1.  Includes the necessary source code from the `vendor/llama.cpp` submodule.
+2.  Excludes unnecessary large directories from `vendor/llama.cpp` (like `models/` and the original `examples/`) to keep the package size reasonable.
+3.  Ensures that the packaged C++ code can be successfully built when the wheel is installed by a user (e.g., via `pip install`).
+
+## Challenges and Solutions
+
+### 1. Including the Submodule
+
+-   **Challenge**: Standard Python packaging tools might not automatically include files from git submodules or might require specific configurations.
+-   **Solution**:
+    -   The `vendor/` directory is made a Python package by adding `vendor/__init__.py`.
+    -   `setup.py` uses `find_packages()` and `include_package_data=True`.
+    -   `MANIFEST.in` uses `graft vendor/llama.cpp` to pull in all files from the submodule.
+
+### 2. Excluding Unnecessary Directories
+
+-   **Challenge**: The `vendor/llama.cpp` submodule contains large directories like `models/` and an extensive `examples/` directory that are not needed for the core functionality of the Python package and would bloat its size.
+-   **Solution**:
+    -   `MANIFEST.in` uses `prune` directives:
+        -   `prune vendor/llama.cpp/.git` (removes git metadata)
+        -   `prune vendor/llama.cpp/models`
+        -   `prune vendor/llama.cpp/examples` (initially removes all original examples)
+
+### 3. Handling CMake Configuration for `llama.cpp`
+
+-   **Challenge**: The `llama.cpp` CMake build system might try to build components (like examples) that we intend to exclude or that might cause issues if their source files are missing from the packaged distribution.
+-   **Solution**: The `build_package.py` script automates modifications to the `vendor/llama.cpp/CMakeLists.txt` file *before* the Python packaging commands are run:
+    -   It sets the CMake option `LLAMA_BUILD_EXAMPLES` to `OFF`.
+    -   It comments out the `add_subdirectory(examples)` line.
+    This prevents the `llama.cpp` build system from attempting to compile the examples.
+
+### 4. The `build_package.py` Automation Script
+
+To streamline the build process and ensure consistency, the `build_package.py` script was created. It performs the following key steps:
+
+1.  **Update Submodule**:
+    -   Initializes the `vendor/llama.cpp` submodule if it hasn\'t been already.
+    -   Fetches the latest tags for the submodule.
+    -   Checks out the submodule to the most recent release tag.
+    -   Commits the submodule pointer update in the parent repository if it changed.
+2.  **Reset Submodule State**:
+    -   Runs `git reset --hard HEAD` and `git clean -fdx` in `vendor/llama.cpp` to ensure a clean, known state based on the checked-out tag, discarding any local modifications or untracked files within the submodule.
+3.  **Modify CMake Configuration**:
+    -   Applies the CMake modifications mentioned in point #3 to `vendor/llama.cpp/CMakeLists.txt`.
+4.  **Clean and Build**:
+    -   Removes previous build artifacts (`dist/`, `build/`, `*.egg-info/`).
+    -   Builds the source distribution (`sdist`) using `python3 setup.py sdist`.
+    -   Builds the binary wheel (`bdist_wheel`) using `python3 setup.py bdist_wheel`.
+
+**Using the script:**
+```bash
+# Ensure the script is executable
+chmod +x build_package.py
+
+# Run the script from the project root
+python3 build_package.py
+```
+The resulting distributions will be in the `dist/` directory.
+
+## Important Note on the `examples` Directory in the Package
+
+-   The `build_package.py` script modifies `vendor/llama.cpp/CMakeLists.txt` so that the C++ build system *itself* doesn\'t try to build the examples.
+-   `MANIFEST.in` also has `prune vendor/llama.cpp/examples`, which removes the original contents of this directory from the Python package.
+
+-   **Potential Downstream Issue**: Some C++ build systems or parts of the `llama.cpp` CMake setup (even if examples aren\'t built) might still expect an `examples/` directory or a specific file like `examples/CMakeLists.txt` to *exist* in the source tree when the wheel is being installed and the C++ code compiled.
+
+-   **If this becomes an issue**:
+    1.  The `vendor/llama.cpp/examples/` directory would need to be recreated as an empty directory containing only a blank `CMakeLists.txt` *before* running `python3 setup.py bdist_wheel` (and `sdist`). This could be added to the `build_package.py` script.
+        ```bash
+        # Steps to be added to build_package.py before setup.py calls if needed:
+        rm -rf vendor/llama.cpp/examples
+        mkdir -p vendor/llama.cpp/examples
+        touch vendor/llama.cpp/examples/CMakeLists.txt
+        ```
+    2.  `MANIFEST.in` would then need to be adjusted to specifically include this empty `CMakeLists.txt` file after pruning the original examples:
+        ```MANIFEST.in
+        graft vendor/llama.cpp
+        prune vendor/llama.cpp/.git
+        prune vendor/llama.cpp/models
+        prune vendor/llama.cpp/examples       # Removes original examples
+        include vendor/llama.cpp/examples/CMakeLists.txt # Adds back the empty one
+        ```
+    As of `build_package.py` creation (2025-05-21), these steps for creating an empty `examples/CMakeLists.txt` are **not** included in the script, as the primary CMake modification should prevent the examples from being built. This note is for future troubleshooting if downstream build issues arise related to a missing `examples` path.
+
+## Current `MANIFEST.in` (as of 2025-05-21)
+
+```plaintext
+graft vendor/llama.cpp
+prune vendor/llama.cpp/.git
+prune vendor/llama.cpp/models
+prune vendor/llama.cpp/examples
+# recursive-include vendor/llama.cpp * # This line is commented out
+```
+
+This setup relies on the `build_package.py` script to prepare the `vendor/llama.cpp/CMakeLists.txt` correctly so that the pruned directories do not cause build failures.

--- a/build_package.py
+++ b/build_package.py
@@ -1,0 +1,156 @@
+\
+import subprocess
+import os
+import shutil
+
+# --- Configuration ---
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__)) # Assumes script is in project root
+LLAMA_CPP_SUBMODULE_PATH = os.path.join(PROJECT_ROOT, "vendor", "llama.cpp")
+LLAMA_CPP_EXAMPLES_PATH = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "examples")
+LLAMA_CPP_MODELS_PATH = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "models")
+LLAMA_CPP_CMAKE_FILE = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "CMakeLists.txt")
+
+def run_command(command, cwd=None, check=True, shell=False):
+    """Helper function to run a shell command."""
+    print(f"Running command: {command if shell else ' '.join(command)} (in {cwd or PROJECT_ROOT})")
+    process = subprocess.run(command, cwd=cwd, capture_output=True, text=True, shell=shell)
+    if check and process.returncode != 0:
+        print(f"Error running command: {command if shell else ' '.join(command)}")
+        print(f"Stdout: {process.stdout}")
+        print(f"Stderr: {process.stderr}")
+        raise subprocess.CalledProcessError(process.returncode, command, output=process.stdout, stderr=process.stderr)
+    return process
+
+def modify_cmake_config():
+    """
+    Modifies the CMakeLists.txt in vendor/llama.cpp to:
+    1. Set LLAMA_BUILD_EXAMPLES to OFF.
+    2. Comment out `add_subdirectory(examples)`.
+    """
+    print(f"Modifying CMake config: {LLAMA_CPP_CMAKE_FILE}")
+    if not os.path.exists(LLAMA_CPP_CMAKE_FILE):
+        print(f"Error: CMake file not found at {LLAMA_CPP_CMAKE_FILE}")
+        return
+
+    with open(LLAMA_CPP_CMAKE_FILE, 'r') as f:
+        lines = f.readlines()
+
+    new_lines = []
+    modified = False
+    for line in lines:
+        if "option(LLAMA_BUILD_EXAMPLES" in line:
+            if "OFF" not in line:
+                new_lines.append("option(LLAMA_BUILD_EXAMPLES \\"llama: build examples\\" OFF) # Modified by build script\n")
+                print(" - Set LLAMA_BUILD_EXAMPLES to OFF")
+                modified = True
+            else:
+                new_lines.append(line) # Already off
+        elif "add_subdirectory(examples)" in line and not line.strip().startswith("#"):
+            new_lines.append("# " + line) # Comment out adding the examples subdirectory
+            print(" - Commented out add_subdirectory(examples)")
+            modified = True
+        else:
+            new_lines.append(line)
+
+    if modified:
+        with open(LLAMA_CPP_CMAKE_FILE, 'w') as f:
+            f.writelines(new_lines)
+        print("CMake config modified.")
+    else:
+        print("CMake config already up-to-date.")
+
+def main():
+    os.chdir(PROJECT_ROOT) # Ensure commands run from project root
+
+    # --- 1. Update submodule to latest release tag ---
+    print("\\n--- Step 1: Updating submodule to latest release tag ---")
+    try:
+        run_command(["git", "submodule", "update", "--init", "--recursive"], cwd=PROJECT_ROOT) # Ensure submodule is initialized
+        run_command(["git", "fetch", "--tags", "--force"], cwd=LLAMA_CPP_SUBMODULE_PATH) # Force fetch tags
+
+        # Get the latest tag name (sorts tags by version and picks the last one)
+        # This assumes semantic versioning (vX.Y.Z or X.Y.Z)
+        result = run_command(
+            "git tag -l | sort -V | tail -n 1",
+            cwd=LLAMA_CPP_SUBMODULE_PATH,
+            shell=True # sort and tail are shell operations
+        )
+        latest_tag = result.stdout.strip()
+
+        if not latest_tag:
+            print("No tags found in submodule. Skipping tag checkout.")
+        else:
+            print(f"Latest tag found: {latest_tag}")
+            current_submodule_commit = run_command(["git", "rev-parse", "HEAD"], cwd=LLAMA_CPP_SUBMODULE_PATH).stdout.strip()
+            run_command(["git", "checkout", latest_tag], cwd=LLAMA_CPP_SUBMODULE_PATH)
+            new_submodule_commit = run_command(["git", "rev-parse", "HEAD"], cwd=LLAMA_CPP_SUBMODULE_PATH).stdout.strip()
+
+            if current_submodule_commit != new_submodule_commit:
+                run_command(["git", "add", os.path.relpath(LLAMA_CPP_SUBMODULE_PATH, PROJECT_ROOT)], cwd=PROJECT_ROOT)
+                commit_message = f"Update {os.path.basename(LLAMA_CPP_SUBMODULE_PATH)} submodule to tag {latest_tag}"
+                # Check if there are staged changes before committing
+                status_result = run_command(["git", "status", "--porcelain"], cwd=PROJECT_ROOT)
+                if status_result.stdout:
+                    run_command(["git", "commit", "-m", commit_message], cwd=PROJECT_ROOT)
+                    print(f"Committed update for submodule to tag {latest_tag}.")
+                else:
+                    print("No changes to commit regarding submodule pointer.")
+            else:
+                print(f"Submodule already at tag {latest_tag}.")
+        print("Submodule updated.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error during submodule update: {e}")
+        print("Continuing with the build, but submodule might not be at the latest tag.")
+    except Exception as e:
+        print(f"An unexpected error occurred during submodule update: {e}")
+        print("Continuing with the build, but submodule might not be at the latest tag.")
+
+
+    # --- 2. Fetch current source from git submodule (Reset any local changes) ---
+    print("\\n--- Step 2: Resetting submodule to fetched state ---")
+    try:
+        run_command(["git", "reset", "--hard", "HEAD"], cwd=LLAMA_CPP_SUBMODULE_PATH)
+        run_command(["git", "clean", "-fdx"], cwd=LLAMA_CPP_SUBMODULE_PATH)
+        print("Submodule reset to clean state.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error during submodule reset: {e}")
+        # Decide if this is a fatal error or if you can continue
+        return # Or raise
+
+    # --- 3. Modify CMake config so that it does not expect examples directory ---
+    print("\\n--- Step 3: Modifying CMake configuration ---")
+    try:
+        modify_cmake_config()
+    except Exception as e:
+        print(f"Error modifying CMake config: {e}")
+        return # Or raise
+
+    # --- 4. Generate source and binary wheel ---
+    print("\\n--- Step 4: Building the wheel ---")
+    # Clean previous builds
+    print("Cleaning previous build artifacts...")
+    if os.path.exists(os.path.join(PROJECT_ROOT, "dist")):
+        shutil.rmtree(os.path.join(PROJECT_ROOT, "dist"))
+    if os.path.exists(os.path.join(PROJECT_ROOT, "build")):
+        shutil.rmtree(os.path.join(PROJECT_ROOT, "build"))
+    
+    egg_info_dirs = [d for d in os.listdir(PROJECT_ROOT) if d.endswith(".egg-info")]
+    for egg_dir in egg_info_dirs:
+        shutil.rmtree(os.path.join(PROJECT_ROOT, egg_dir))
+
+    # Build the wheel
+    try:
+        print("Building sdist...")
+        run_command(["python3", "setup.py", "sdist"], cwd=PROJECT_ROOT)
+        print("Building bdist_wheel...")
+        run_command(["python3", "setup.py", "bdist_wheel"], cwd=PROJECT_ROOT)
+        print("Wheel build process completed.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error during wheel build: {e}")
+        return # Or raise
+    
+    print("\\n--- Automation Script Finished ---")
+    print(f"Check the '{os.path.join(PROJECT_ROOT, 'dist')}' directory for the generated wheel and source distribution.")
+
+if __name__ == "__main__":
+    main()

--- a/build_package.py
+++ b/build_package.py
@@ -2,6 +2,7 @@
 import subprocess
 import os
 import shutil
+import re # For regex operations on setup.py
 
 # --- Configuration ---
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__)) # Assumes script is in project root
@@ -9,6 +10,7 @@ LLAMA_CPP_SUBMODULE_PATH = os.path.join(PROJECT_ROOT, "vendor", "llama.cpp")
 LLAMA_CPP_EXAMPLES_PATH = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "examples")
 LLAMA_CPP_MODELS_PATH = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "models")
 LLAMA_CPP_CMAKE_FILE = os.path.join(LLAMA_CPP_SUBMODULE_PATH, "CMakeLists.txt")
+SETUP_PY_PATH = os.path.join(PROJECT_ROOT, "setup.py")
 
 def run_command(command, cwd=None, check=True, shell=False):
     """Helper function to run a shell command."""
@@ -59,8 +61,61 @@ def modify_cmake_config():
     else:
         print("CMake config already up-to-date.")
 
+def get_current_version(file_path):
+    """Reads setup.py and extracts the version."""
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", content)
+        if match:
+            return match.group(1)
+        raise ValueError(f"Could not find version pattern in {file_path}")
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Error: {file_path} not found.")
+    except Exception as e:
+        raise Exception(f"Error reading version from {file_path}: {e}")
+
+def update_version_in_setup_py(file_path, new_version, old_version):
+    """Writes the new version to setup.py."""
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        
+        old_version_pattern = r"version\s*=\s*['\"]" + re.escape(old_version) + r"['\"]"
+        new_version_string = f"version='{new_version}'" # Standardize on single quotes for the new version
+        
+        if not re.search(old_version_pattern, content):
+            print(f"Warning: Old version '{old_version}' not found in {file_path} as expected using pattern '{old_version_pattern}'. Version not updated.")
+            return
+
+        new_content, num_replacements = re.subn(old_version_pattern, new_version_string, content, count=1)
+        
+        if num_replacements == 0:
+            print(f"Warning: Old version '{old_version}' was not replaced in {file_path}. Check the version string and pattern.")
+            return
+
+        with open(file_path, 'w') as f:
+            f.write(new_content)
+        print(f"Updated version in {file_path} from {old_version} to {new_version}")
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found during version update.")
+    except Exception as e:
+        print(f"Error updating version in {file_path}: {e}")
+
+
 def main():
     os.chdir(PROJECT_ROOT) # Ensure commands run from project root
+
+    try:
+        current_version = get_current_version(SETUP_PY_PATH)
+        print(f"Current package version from setup.py: {current_version}")
+    except Exception as e:
+        print(f"Fatal error: Could not retrieve current version from setup.py. {e}")
+        return # Exit if we can't get the version
+
+    # This variable will hold the version that should be used by the build.
+    # It starts as current_version and might be updated if a new tag is processed.
+    effective_version_for_build = current_version
 
     # --- 1. Update submodule to latest release tag ---
     print("\\n--- Step 1: Updating submodule to latest release tag ---")
@@ -86,18 +141,47 @@ def main():
             new_submodule_commit = run_command(["git", "rev-parse", "HEAD"], cwd=LLAMA_CPP_SUBMODULE_PATH).stdout.strip()
 
             if current_submodule_commit != new_submodule_commit:
+                print(f"Submodule updated from {current_submodule_commit[:7]} to {new_submodule_commit[:7]} (tag {latest_tag}).")
+                
+                version_changed_this_run = False
+                potential_new_version = current_version # Start with current version
+
+                # Try to increment version
+                version_parts = current_version.split('.')
+                if len(version_parts) >= 3: # Expecting at least X.Y.Z
+                    try:
+                        version_parts[-1] = str(int(version_parts[-1]) + 1)
+                        potential_new_version = ".".join(version_parts)
+                        version_changed_this_run = True
+                    except ValueError:
+                        print(f"Warning: Could not parse and increment patch version for '{current_version}'. Version not incremented.")
+                else:
+                    print(f"Warning: Version '{current_version}' from setup.py does not have at least 3 parts (X.Y.Z). Version not incremented.")
+                
+                # Stage submodule update
                 run_command(["git", "add", os.path.relpath(LLAMA_CPP_SUBMODULE_PATH, PROJECT_ROOT)], cwd=PROJECT_ROOT)
-                commit_message = f"Update {os.path.basename(LLAMA_CPP_SUBMODULE_PATH)} submodule to tag {latest_tag}"
+                commit_message_parts = [f"Update {os.path.basename(LLAMA_CPP_SUBMODULE_PATH)} to {latest_tag}"]
+
+                if version_changed_this_run:
+                    update_version_in_setup_py(SETUP_PY_PATH, potential_new_version, current_version) # Write to file
+                    run_command(["git", "add", SETUP_PY_PATH], cwd=PROJECT_ROOT) # Add setup.py
+                    commit_message_parts.append(f"bump version to {potential_new_version}")
+                    effective_version_for_build = potential_new_version # Update the version for this build run
+                
+                final_commit_message = ", ".join(commit_message_parts)
+                
                 # Check if there are staged changes before committing
                 status_result = run_command(["git", "status", "--porcelain"], cwd=PROJECT_ROOT)
-                if status_result.stdout:
-                    run_command(["git", "commit", "-m", commit_message], cwd=PROJECT_ROOT)
-                    print(f"Committed update for submodule to tag {latest_tag}.")
+                if status_result.stdout.strip(): # Ensure there's something to commit
+                    run_command(["git", "commit", "-m", final_commit_message], cwd=PROJECT_ROOT)
+                    print(f"Committed: {final_commit_message}")
                 else:
-                    print("No changes to commit regarding submodule pointer.")
+                    # This case might happen if the submodule was already on the tag,
+                    # but the main repo hadn't committed that submodule state yet.
+                    print("No changes staged for commit, or submodule pointer was already up-to-date and committed.")
             else:
-                print(f"Submodule already at tag {latest_tag}.")
-        print("Submodule updated.")
+                print(f"Submodule {os.path.basename(LLAMA_CPP_SUBMODULE_PATH)} already at tag {latest_tag}.")
+        print("Submodule update process finished.")
     except subprocess.CalledProcessError as e:
         print(f"Error during submodule update: {e}")
         print("Continuing with the build, but submodule might not be at the latest tag.")
@@ -125,6 +209,7 @@ def main():
         print(f"Error modifying CMake config: {e}")
         return # Or raise
 
+    print(f"Proceeding to build with version: {effective_version_for_build}")
     # --- 4. Generate source and binary wheel ---
     print("\\n--- Step 4: Building the wheel ---")
     # Clean previous builds

--- a/build_package.py
+++ b/build_package.py
@@ -40,7 +40,7 @@ def modify_cmake_config():
     for line in lines:
         if "option(LLAMA_BUILD_EXAMPLES" in line:
             if "OFF" not in line:
-                new_lines.append("option(LLAMA_BUILD_EXAMPLES \\"llama: build examples\\" OFF) # Modified by build script\n")
+                new_lines.append('option(LLAMA_BUILD_EXAMPLES "llama: build examples" OFF) # Modified by build script\\n')
                 print(" - Set LLAMA_BUILD_EXAMPLES to OFF")
                 modified = True
             else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='llama_cpp',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='llama_cpp',
-    version='0.1.1',
+    name='llama_cpp_pydist',
+    version='0.1.3',
     packages=find_packages(),
     include_package_data=True,
+    package_data={
+        # If any package contains *.txt or *.rst files, include them:
+        "": ["*.txt", "*.rst"],
+        # And include any *.dat files found in the 'data' subdirectory
+        # of the 'mypkg' package, also:
+        "llama_cpp": ["vendor/llama.cpp/**/*"],
+    },
     install_requires=[
         # Add any dependencies here
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='llama_cpp_pydist',
-    version='0.1.4',
+    version='0.1.5',
     packages=find_packages(),
     include_package_data=True,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='llama_cpp_pydist',
-    version='0.1.3',
+    version='0.1.4',
     packages=find_packages(),
     include_package_data=True,
     package_data={

--- a/vendor/__init__.py
+++ b/vendor/__init__.py
@@ -1,0 +1,1 @@
+# This file makes 'vendor' a Python package


### PR DESCRIPTION
This pull request introduces significant updates to streamline the packaging and distribution of the `llama_cpp_pydist` Python package. The changes focus on improving the inclusion and management of the `vendor/llama.cpp` submodule, automating the build process, and refining the package structure to ensure a clean and efficient build.

### Packaging and Submodule Management:

* **`MANIFEST.in`**: Updated to prune unnecessary directories (`models`, `examples`, and `.git`) from the `vendor/llama.cpp` submodule to reduce package size.
* **`setup.py`**: Renamed the package to `llama_cpp_pydist`, updated the version to `0.1.5`, and added `package_data` to include specific files from the `llama.cpp` directory in the package.

### Build Automation:

* **`build_package.py`**: Added a new script to automate the build process, including submodule updates, CMake configuration modifications (e.g., disabling `LLAMA_BUILD_EXAMPLES`), and wheel generation. This ensures consistency and reduces manual effort.

### Documentation Updates:

* **`README.md`**: Added a new section detailing the steps to build the Python wheel, including ensuring the `vendor` directory is recognized as a package and cleaning previous builds.
* **`build_notes.md`**: Created a comprehensive document explaining the build process, challenges, and solutions, including handling submodule inclusion, pruning unnecessary files, and modifying CMake configurations.